### PR TITLE
Better aria-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the following snippet to where you want your sharing button to show up:
       name="fediverse-domain"
       placeholder="mastodon.social"
       class="fsb-input fsb-domain"
-      aria-label="Amount (to the nearest dollar)">
+      aria-label="Server domain">
     <button class="fsb-button"
       type="submit"><img src="https://fediverse-share-button.stefanbohacek.dev/fediverse-share-button/icons/mastodon.svg"
         class="fsb-icon"></span>Share</button>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         name="fediverse-domain"
         placeholder="mastodon.social"
         class="fsb-input fsb-domain"
-        aria-label="Amount (to the nearest dollar)">
+        aria-label="Server domain">
       <button class="fsb-button"
         type="submit"><img alt="Fediverse platform logo" src="./fediverse-share-button/icons/mastodon.svg"
           class="fsb-icon"></span>Share</button>


### PR DESCRIPTION
The `aria-label` for the input field was "Amount (to the nearest dollar)" which I think is probably accidentally copy-pasted from Bootstrap's [input group](https://getbootstrap.com/docs/4.0/components/input-group/) code examples 😉.

Changing it to 'Server domain'. If there's a better copy suggestion, I'll update this PR 🙏